### PR TITLE
fix: bundle timer worker and prerender presenter routes for static re…

### DIFF
--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const trailingSlash = 'always';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
 		<div>
 			<div class="flex flex-row gap-3">
 				<div>Hackerspace MMU</div>
-				<div>v4.1.0</div>
+				<div>v4.1.1</div>
 			</div>
 		</div>
 	</footer>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -154,9 +154,9 @@
 
 	function startPresentation(category: string) {
 		if (category === 'idea') {
-			goto('presentation/ideatalk');
+			goto('presentation/ideatalk/');
 		} else {
-			goto('presentation/progresstalk');
+			goto('presentation/progresstalk/');
 		}
 	}
 

--- a/src/routes/presentation/ideatalk/+page.svelte
+++ b/src/routes/presentation/ideatalk/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { randomIdeaArrayStore } from '$lib/stores';
+	import TimerWorker from '$lib/timerWorker.ts?worker';
 	import { onMount } from 'svelte';
 	let randomArray: string[] = [];
 	const IDEA_ORDER_KEY = 'randomIdeaOrder';
@@ -63,7 +64,7 @@
 
 	function startPauseTimer() {
 		if (!worker) {
-			worker = new Worker('/random/timerWorker.js');
+			worker = new TimerWorker();
 			worker.addEventListener('message', (event) => {
 				const speechSynthesis = window.speechSynthesis;
 				let speechUtterance;

--- a/src/routes/presentation/progresstalk/+page.svelte
+++ b/src/routes/presentation/progresstalk/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { randomProgressArrayStore } from '$lib/stores';
+	import TimerWorker from '$lib/timerWorker.ts?worker';
 	import { onMount } from 'svelte';
 	let randomArray: string[] = [];
 	const PROGRESS_ORDER_KEY = 'randomProgressOrder';
@@ -63,7 +64,7 @@
 
 	function startPauseTimer() {
 		if (!worker) {
-			worker = new Worker('/random/timerWorker.js');
+			worker = new TimerWorker();
 			worker.addEventListener('message', (event) => {
 				const speechSynthesis = window.speechSynthesis;
 				let speechUtterance;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,21 +3,22 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	preprocess: vitePreprocess(),
+        preprocess: vitePreprocess(),
 
-	kit: {
-		adapter: adapter({
-			pages: 'build',
-			assets: 'build',
-			fallback: 'index.html'
-		}),
-		paths: {
-			base: '/random'
-		},
-		prerender: {
-			handleMissingId: 'warn'
-		}
-	}
+        kit: {
+                adapter: adapter({
+                        pages: 'build',
+                        assets: 'build',
+                        fallback: 'index.html'
+                }),
+                paths: {
+                        base: '/random'
+                },
+                prerender: {
+                        handleMissingId: 'warn',
+                        entries: ['*', '/presentation/ideatalk', '/presentation/progresstalk']
+                }
+        }
 };
 
 export default config;


### PR DESCRIPTION
…fresh

- use Vite worker import for presenter timers so countdown updates work in production
- enable prerender for presenter routes and trailing slash behavior
- update presenter navigation URLs to slash-suffixed paths for static hosting compatibility