### PR TITLE
feat: integrate with hacktrack to get recent talks for presenter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,15 @@
 			"name": "random",
 			"version": "0.0.1",
 			"dependencies": {
-				"@sveltejs/adapter-static": "^3.0.4"
+				"@sveltejs/adapter-static": "^3.0.4",
+				"qrcode": "^1.5.4"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^3.0.0",
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
 				"@types/eslint": "^9.6.0",
+				"@types/qrcode": "^1.5.6",
 				"autoprefixer": "^10.4.20",
 				"eslint": "^9.0.0",
 				"eslint-config-prettier": "^9.1.0",
@@ -1148,6 +1150,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/node": {
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": ">=7.24.0 <7.24.7"
+			}
+		},
+		"node_modules/@types/qrcode": {
+			"version": "1.5.6",
+			"resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+			"integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.4.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.4.0.tgz",
@@ -1420,7 +1442,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -1430,7 +1451,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -1633,6 +1653,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/camelcase-css": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1719,6 +1748,51 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/code-red": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
@@ -1736,7 +1810,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -1749,7 +1822,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/commander": {
@@ -1836,6 +1908,15 @@
 				}
 			}
 		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1873,6 +1954,12 @@
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/dijkstrajs": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+			"integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+			"license": "MIT"
 		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
@@ -2391,6 +2478,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
 		"node_modules/glob": {
 			"version": "10.4.5",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -2596,7 +2692,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -3027,6 +3122,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -3051,7 +3155,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -3141,6 +3244,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/pngjs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+			"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -3377,6 +3489,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/qrcode": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+			"integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+			"license": "MIT",
+			"dependencies": {
+				"dijkstrajs": "^1.0.1",
+				"pngjs": "^5.0.0",
+				"yargs": "^15.3.1"
+			},
+			"bin": {
+				"qrcode": "bin/qrcode"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -3433,6 +3562,21 @@
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"license": "ISC"
 		},
 		"node_modules/resolve": {
 			"version": "1.22.8",
@@ -3559,6 +3703,12 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"license": "ISC"
 		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.7.0",
@@ -3699,7 +3849,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -4146,6 +4295,13 @@
 				}
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+			"devOptional": true,
+			"license": "MIT"
+		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
@@ -4283,6 +4439,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"license": "ISC"
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4394,6 +4556,12 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
+		"node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"license": "ISC"
+		},
 		"node_modules/yaml": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
@@ -4402,6 +4570,113 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/yargs/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yargs/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"@types/eslint": "^9.6.0",
+		"@types/qrcode": "^1.5.6",
 		"autoprefixer": "^10.4.20",
 		"eslint": "^9.0.0",
 		"eslint-config-prettier": "^9.1.0",
@@ -33,6 +34,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@sveltejs/adapter-static": "^3.0.4"
+		"@sveltejs/adapter-static": "^3.0.4",
+		"qrcode": "^1.5.4"
 	}
 }

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -2,3 +2,6 @@ import { writable } from 'svelte/store';
 
 export const randomIdeaArrayStore = writable(/** @type {string[]} */ ([]));
 export const randomProgressArrayStore = writable(/** @type {string[]} */ ([]));
+export const authSessionStore = writable(
+	/** @type {{ token: string; expiresAt: number }} */ ({ token: '', expiresAt: 0 })
+);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
 		<div>
 			<div class="flex flex-row gap-3">
 				<div>Hackerspace MMU</div>
-				<div>v4.1.1</div>
+				<div>v4.2.0</div>
 			</div>
 		</div>
 	</footer>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { randomIdeaArrayStore, randomProgressArrayStore } from '$lib/stores';
+	import { authSessionStore, randomIdeaArrayStore, randomProgressArrayStore } from '$lib/stores';
 	import { goto } from '$app/navigation';
 
 	let ideaTalkInput = '';
@@ -8,8 +8,50 @@
 	let randomIdealTalkArray: string[] = [];
 	let randomProgressTalkArray: string[] = [];
 	let isExtracting = false;
+	let apiPassword = '';
+	let isAuthenticating = false;
+	let authError = '';
+	let isSessionValid = false;
 	const IDEA_ORDER_KEY = 'randomIdeaOrder';
 	const PROGRESS_ORDER_KEY = 'randomProgressOrder';
+	const SESSION_STORAGE_KEY = 'publicApiSession';
+	const EXTERNAL_API_BASE_URL = (import.meta.env.VITE_EXTERNAL_API_BASE_URL || '').replace(/\/$/, '');
+
+	const DEFAULT_SESSION_TOKEN_TTL_SECONDS = 2 * 60 * 60; // 2 hours
+
+	function getSessionTokenFromAuthPayload(authenticatePayload: any): string {
+		return (
+			authenticatePayload?.session_token ||
+			''
+		);
+	}
+
+	function getSessionTokenExpiryFromAuthPayload(authenticatePayload: any): number {
+		const expiresInSeconds = Number(
+			authenticatePayload?.expires_in ||
+			DEFAULT_SESSION_TOKEN_TTL_SECONDS
+		);
+
+		const safeSeconds =
+			Number.isFinite(expiresInSeconds) && expiresInSeconds > 0
+				? expiresInSeconds
+				: DEFAULT_SESSION_TOKEN_TTL_SECONDS;
+
+		const refreshBufferSeconds = 10;
+		return Date.now() + Math.max(1, safeSeconds - refreshBufferSeconds) * 1000;
+	}
+
+	function saveSession(session: { token: string; expiresAt: number }) {
+		authSessionStore.set(session);
+		sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+	}
+
+	function clearSession() {
+		authSessionStore.set({ token: '', expiresAt: 0 });
+		sessionStorage.removeItem(SESSION_STORAGE_KEY);
+	}
+
+	$: isSessionValid = $authSessionStore.token.length > 0 && Date.now() < $authSessionStore.expiresAt;
 
 	function loadStoredOrder(key: string): string[] {
 		const raw = localStorage.getItem(key);
@@ -71,7 +113,79 @@
 
 		ideaTalkInput = localStorage.getItem('randomIdeaName') || '';
 		progressTalkInput = localStorage.getItem('randomProgressName') || '';
+
+		const storedSession = sessionStorage.getItem(SESSION_STORAGE_KEY);
+		if (storedSession) {
+			try {
+				const parsed = JSON.parse(storedSession);
+				if (typeof parsed?.token === 'string' && typeof parsed?.expiresAt === 'number') {
+					authSessionStore.set({ token: parsed.token, expiresAt: parsed.expiresAt });
+				}
+			} catch {
+				sessionStorage.removeItem(SESSION_STORAGE_KEY);
+			}
+		}
 	});
+
+	async function authenticateSession() {
+		authError = '';
+		if (!EXTERNAL_API_BASE_URL) {
+			authError = 'Missing VITE_EXTERNAL_API_BASE_URL configuration.';
+			return;
+		}
+
+		if (!apiPassword.trim()) {
+			authError = 'Please enter password.';
+			return;
+		}
+
+		isAuthenticating = true;
+		try {
+			const authenticateResponse = await fetch(`${EXTERNAL_API_BASE_URL}/api/v1/public/authenticate`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ password: apiPassword })
+			});
+
+			if (!authenticateResponse.ok) {
+				if (authenticateResponse.status === 401) {
+					throw new Error('Wrong password.');
+				}
+				if (authenticateResponse.status === 400) {
+					throw new Error('Password is required.');
+				}
+				const detail = await authenticateResponse.text();
+				throw new Error(`Authenticate failed (${authenticateResponse.status}): ${detail}`);
+			}
+
+			const authenticatePayload = await authenticateResponse.json();
+			const sessionToken = getSessionTokenFromAuthPayload(authenticatePayload);
+
+			if (!sessionToken) {
+				throw new Error('Authenticate response does not contain session token.');
+			}
+
+			saveSession({
+				token: sessionToken,
+				expiresAt: getSessionTokenExpiryFromAuthPayload(authenticatePayload)
+			});
+			apiPassword = '';
+		} catch (error) {
+			authError = error instanceof Error ? error.message : 'Authentication failed.';
+			clearSession();
+		} finally {
+			isAuthenticating = false;
+		}
+	}
+
+	function handlePasswordKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			void authenticateSession();
+		}
+	}
 
 	function shuffleArray(array: string[]) {
 		for (var i = array.length - 1; i > 0; i--) {
@@ -171,6 +285,7 @@
 		localStorage.removeItem('randomProgressName');
 		localStorage.removeItem(IDEA_ORDER_KEY);
 		localStorage.removeItem(PROGRESS_ORDER_KEY);
+		clearSession();
 	}
 
 	async function extractFormResponses() {
@@ -213,6 +328,36 @@
 			here
 		</a>
 	</p>
+	<div class="my-4 p-3 border border-stone-300 rounded bg-white">
+		<div class="flex gap-2 flex-wrap items-center text-sm">
+			<p class="text-xs">{isSessionValid ? '🟢' : '🔴'}</p>
+			<p class="font-semibold">
+				{isSessionValid
+					? 'Logged in (HackTrack context for ProgressTalks)'
+					: 'Login (HackTrack context for ProgressTalks)'}
+			</p>
+			{#if !isSessionValid}
+				<input
+					id="mainApiPassword"
+					type="password"
+					bind:value={apiPassword}
+					placeholder="Password"
+					class="text-black p-2 rounded border border-stone-300"
+					on:keydown={handlePasswordKeydown}
+				/>
+				<button
+					class="bg-red-500 hover:bg-orange-500 text-white py-2 px-4 rounded"
+					on:click={authenticateSession}
+					disabled={isAuthenticating}
+				>
+					{isAuthenticating ? 'Logging in...' : 'Login'}
+				</button>
+			{/if}
+		</div>
+		{#if authError}
+			<p class="text-red-600 text-sm mt-2">{authError}</p>
+		{/if}
+	</div>
 	<div class="textarea flex gap-2 w-full my-4">
 		<div class="w-1/2">
 			<p class="font-semibold my-2 text-sm">IdeaTalk</p>

--- a/src/routes/presentation/progresstalk/+page.svelte
+++ b/src/routes/presentation/progresstalk/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-	import { randomProgressArrayStore } from '$lib/stores';
+	import { authSessionStore, randomProgressArrayStore } from '$lib/stores';
 	import TimerWorker from '$lib/timerWorker.ts?worker';
+	import QRCode from 'qrcode';
 	import { onMount } from 'svelte';
 	let randomArray: string[] = [];
 	const PROGRESS_ORDER_KEY = 'randomProgressOrder';
+	const EXTERNAL_API_BASE_URL = (import.meta.env.VITE_EXTERNAL_API_BASE_URL || '').replace(/\/$/, '');
 	let currentPresenterIndex = 0;
 	let currentPresenter = '';
 	let nextPresenter = '';
@@ -11,6 +13,48 @@
 	let timer = Math.floor(customMinutes * 60);
 	let isRunning = false;
 	let worker: Worker | undefined;
+	let isGeneratingActivationLink = false;
+	let activationError = '';
+	let activationResponse: { url: string; member_name?: string; expires_in?: number } | null = null;
+	let qrCodeDataUrl = '';
+	let isQrWidgetMinimized = false;
+	let hasCopiedLink = false;
+	const SESSION_STORAGE_KEY = 'publicApiSession';
+
+	function getValidSharedSessionToken(): string {
+		if ($authSessionStore.token && Date.now() < $authSessionStore.expiresAt) {
+			return $authSessionStore.token;
+		}
+		return '';
+	}
+
+	function clearSharedSessionToken() {
+		authSessionStore.set({ token: '', expiresAt: 0 });
+		sessionStorage.removeItem(SESSION_STORAGE_KEY);
+	}
+
+	async function activateWithToken(sessionToken: string) {
+		const activateResponse = await fetch(`${EXTERNAL_API_BASE_URL}/api/v1/public/activate`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${sessionToken}`
+			},
+			body: JSON.stringify({ name: currentPresenter })
+		});
+
+		if (!activateResponse.ok) {
+			if (activateResponse.status === 400) {
+				throw new Error('Presenter name is required.');
+			} else if (activateResponse.status === 404) {
+				throw new Error('Name not found in HackTrack.');
+			}
+			const detail = await activateResponse.text();
+			throw new Error(`Activate failed (${activateResponse.status}): ${detail}`);
+		}
+
+		return activateResponse.json();
+	}
 
 	function getSavedOrder(): string[] {
 		const raw = localStorage.getItem(PROGRESS_ORDER_KEY);
@@ -32,10 +76,31 @@
 		if (randomArray.length > 0) {
 			currentPresenter = randomArray[0];
 			nextPresenter = randomArray[1];
+			clearActivationState();
+			void generateActivationLink();
 		}
 	}
 
+	function clearActivationState() {
+		activationError = '';
+		activationResponse = null;
+		qrCodeDataUrl = '';
+		hasCopiedLink = false;
+	}
+
 	onMount(() => {
+		const storedSession = sessionStorage.getItem(SESSION_STORAGE_KEY);
+		if (storedSession) {
+			try {
+				const parsed = JSON.parse(storedSession);
+				if (typeof parsed?.token === 'string' && typeof parsed?.expiresAt === 'number') {
+					authSessionStore.set({ token: parsed.token, expiresAt: parsed.expiresAt });
+				}
+			} catch {
+				sessionStorage.removeItem(SESSION_STORAGE_KEY);
+			}
+		}
+
 		randomProgressArrayStore.subscribe((value) => {
 			randomArray = value;
 			updatePresenters();
@@ -97,7 +162,9 @@
 			currentPresenterIndex++;
 			currentPresenter = randomArray[currentPresenterIndex];
 			nextPresenter = randomArray[currentPresenterIndex + 1];
+			clearActivationState();
 			resetTimer();
+			void generateActivationLink();
 		} else {
 			alert('Presentation complete!');
 		}
@@ -116,6 +183,72 @@
 
 	function updateCustomTimer() {
 		timer = Math.floor(customMinutes * 60);
+	}
+
+	async function copyActivationUrl() {
+		if (!activationResponse?.url) return;
+		await navigator.clipboard.writeText(activationResponse.url);
+		hasCopiedLink = true;
+	}
+
+	async function generateActivationLink() {
+		activationError = '';
+		activationResponse = null;
+		qrCodeDataUrl = '';
+
+		if (!EXTERNAL_API_BASE_URL) {
+			activationError = 'Missing VITE_EXTERNAL_API_BASE_URL configuration.';
+			return;
+		}
+
+		if (!currentPresenter.trim()) {
+			activationError = 'No current presenter found.';
+			return;
+		}
+
+		isGeneratingActivationLink = true;
+
+		try {
+			const sessionToken = getValidSharedSessionToken();
+			if (!sessionToken) {
+				activationError = 'Session token missing or expired. Please authenticate on the main page.';
+				return;
+			}
+
+			let activatePayload;
+			try {
+				activatePayload = await activateWithToken(sessionToken);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : '';
+				if (message.includes('401') || message.toLowerCase().includes('unauthorized')) {
+					clearSharedSessionToken();
+					activationError = 'Session expired. Please re-authenticate on the main page.';
+					return;
+				} else {
+					throw error;
+				}
+			}
+
+			if (!activatePayload?.url) {
+				throw new Error('Activate response does not contain url.');
+			}
+
+			activationResponse = {
+				url: activatePayload.url,
+				member_name: activatePayload.member_name,
+				expires_in: activatePayload.expires_in
+			};
+			hasCopiedLink = false;
+
+			qrCodeDataUrl = await QRCode.toDataURL(activatePayload.url, {
+				width: 280,
+				margin: 1
+			});
+		} catch (error) {
+			activationError = error instanceof Error ? error.message : 'Unknown error while generating link.';
+		} finally {
+			isGeneratingActivationLink = false;
+		}
 	}
 </script>
 
@@ -188,4 +321,60 @@
 		class="bg-red-500 hover:bg-orange-500 text-white py-2 px-4 rounded"
 		on:click={() => history.back()}>Back</button
 	>
+</div>
+
+<div
+	class={`fixed right-4 z-50 text-black ${isQrWidgetMinimized ? 'bottom-16 w-auto max-w-none' : 'bottom-20 w-80 max-w-[calc(100vw-2rem)]'}`}
+>
+	{#if isQrWidgetMinimized}
+		<button
+			class="bg-red-500 hover:bg-orange-500 text-white px-4 py-2 rounded-full shadow-lg text-sm"
+			on:click={() => (isQrWidgetMinimized = false)}
+		>
+			Recent talk
+		</button>
+	{:else}
+		<div class="border border-red-200 rounded p-4 bg-white shadow-lg">
+			<div class="flex items-center justify-between mb-2">
+				<p class="font-semibold">This member's recent talk:</p>
+				<button
+					class="text-xs px-2 py-1 border border-stone-300 rounded hover:bg-stone-100"
+					on:click={() => (isQrWidgetMinimized = true)}
+				>
+					Minimize
+				</button>
+			</div>
+
+			{#if isGeneratingActivationLink}
+				<p class="text-xs text-slate-600 mb-2">Generating link...</p>
+			{/if}
+
+			{#if activationError}
+				<p class="text-red-600 text-sm mt-2">{activationError}</p>
+			{/if}
+
+			{#if activationResponse && qrCodeDataUrl}
+				<div class="mt-4 bg-stone-50 border border-stone-200 rounded p-3">
+					{#if activationResponse.member_name}
+						<p class="text-xs font-semibold">Member: {activationResponse.member_name}</p>
+					{/if}
+					{#if activationResponse.expires_in}
+						<p class="text-xs mt-1">Expires in: {activationResponse.expires_in}</p>
+					{/if}
+					<div class="flex items-center gap-2 mt-2">
+						<button
+							class="bg-stone-200 hover:bg-stone-300 text-black py-1 px-3 rounded text-xs"
+							on:click={copyActivationUrl}
+						>
+							Copy link
+						</button>
+						{#if hasCopiedLink}
+							<p class="text-xs text-green-700">Copied</p>
+						{/if}
+					</div>
+					<img src={qrCodeDataUrl} alt="Member activation QR code" class="rounded w-full h-auto mt-3" />
+				</div>
+			{/if}
+		</div>
+	{/if}
 </div>


### PR DESCRIPTION
feat: integrate HackTrack auth and auto-generate presenter QR links

- add main-page HackTrack login bar with emoji status indicator
- support Enter key submit on password input
- store shared session token in app store and sessionStorage
- use shared token on ProgressTalk presenter page
- auto-generate activation link/QR on page load and when moving to next presenter
- move QR panel to floating, minimizable bottom-right widget above footer
- improve error messages: 400 Password is required, 401 Wrong password, 404 Name not found in HackTrack.